### PR TITLE
refactor: modernize deprecated APIs and fix coding best practices

### DIFF
--- a/backend/db/crud.py
+++ b/backend/db/crud.py
@@ -4,10 +4,6 @@ CRUD (Create, Read, Update, Delete) operations for database models.
 Provides helper functions for database operations.
 """
 
-
-
-
-
 from typing import Optional
 
 from sqlalchemy import desc
@@ -16,6 +12,7 @@ from sqlalchemy.orm import Session
 from . import models
 
 # ==================== Analysis CRUD ====================
+
 
 def create_analysis(db: Session, analysis_data: dict) -> models.Analysis:
     """
@@ -50,10 +47,7 @@ def get_analysis(db: Session, analysis_id: str) -> Optional[models.Analysis]:
 
 
 def get_analyses(
-    db: Session,
-    skip: int = 0,
-    limit: int = 100,
-    format_filter: Optional[str] = None
+    db: Session, skip: int = 0, limit: int = 100, format_filter: Optional[str] = None
 ) -> list[models.Analysis]:
     """
     Get list of analyses with pagination and optional filtering.
@@ -114,6 +108,7 @@ def delete_analysis(db: Session, analysis_id: str) -> bool:
 
 
 # ==================== Triage CRUD ====================
+
 
 def create_triage(db: Session, triage_data: dict) -> models.Triage:
     """

--- a/backend/db/database.py
+++ b/backend/db/database.py
@@ -5,8 +5,7 @@ Provides SQLAlchemy engine, session factory, and base model class.
 """
 
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 # SQLite database URL (will be in root directory for now)
 SQLALCHEMY_DATABASE_URL = "sqlite:///./log_analyzer.db"
@@ -16,14 +15,16 @@ SQLALCHEMY_DATABASE_URL = "sqlite:///./log_analyzer.db"
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL,
     connect_args={"check_same_thread": False},
-    echo=False  # Set to True for SQL query logging
+    echo=False,  # Set to True for SQL query logging
 )
 
 # Create session factory
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
+
 # Create base class for models
-Base = declarative_base()
+class Base(DeclarativeBase):
+    pass
 
 
 def get_db():

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -7,7 +7,7 @@ Models:
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import JSON, Column, DateTime, Float, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
@@ -21,6 +21,7 @@ class Analysis(Base):
 
     Represents the output from LogAnalyzer.analyze(), persisted to database.
     """
+
     __tablename__ = "analyses"
 
     # Primary key
@@ -50,14 +51,10 @@ class Analysis(Base):
     time_span = Column(String, nullable=True)  # Duration as string
 
     # Metadata
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False, index=True)
 
     # Relationships
-    triages = relationship(
-        "Triage",
-        back_populates="analysis",
-        cascade="all, delete-orphan"
-    )
+    triages = relationship("Triage", back_populates="analysis", cascade="all, delete-orphan")
 
     def __repr__(self):
         return f"<Analysis(id={self.id}, filename={self.filename}, format={self.detected_format})>"
@@ -69,18 +66,14 @@ class Triage(Base):
 
     Represents the output from TriageEngine.triage(), linked to an Analysis.
     """
+
     __tablename__ = "triages"
 
     # Primary key
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
 
     # Foreign key to analysis
-    analysis_id = Column(
-        String,
-        ForeignKey("analyses.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True
-    )
+    analysis_id = Column(String, ForeignKey("analyses.id", ondelete="CASCADE"), nullable=False, index=True)
 
     # Triage results
     summary = Column(Text, nullable=False)
@@ -96,7 +89,7 @@ class Triage(Base):
     raw_analysis = Column(Text, nullable=True)  # Full raw AI response
 
     # Metadata
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False, index=True)
 
     # Relationships
     analysis = relationship("Analysis", back_populates="triages")

--- a/backend/logging_middleware.py
+++ b/backend/logging_middleware.py
@@ -17,10 +17,11 @@ logger.setLevel(logging.INFO)
 handler = logging.StreamHandler(sys.stdout)
 formatter = logging.Formatter(
     '{"timestamp": "%(asctime)s", "level": "%(levelname)s", "service": "api", %(message)s}',
-    datefmt='%Y-%m-%dT%H:%M:%S%z'
+    datefmt="%Y-%m-%dT%H:%M:%S%z",
 )
 handler.setFormatter(formatter)
 logger.addHandler(handler)
+
 
 class StructuredLoggingMiddleware(BaseHTTPMiddleware):
     """
@@ -31,17 +32,16 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
         request_id = str(uuid.uuid4())
         start_time = time.time()
 
-        # Add request context
-        {
+        # Request context for logging
+        request_context = {
             "req_id": request_id,
             "method": request.method,
             "path": request.url.path,
             "client_ip": request.client.host if request.client else "unknown",
-            "user_agent": request.headers.get("user-agent", "unknown")
+            "user_agent": request.headers.get("user-agent", "unknown"),
         }
 
-        # Log request (debug level only to avoid noise)
-        # logger.debug(f'"event": "request_received", "context": {str(request_context)}')
+        logger.debug(f'"event": "request_received", "context": {request_context}')
 
         try:
             response = await call_next(request)
@@ -81,4 +81,4 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
                 f'"error": "{str(e)}", '
                 f'"duration_ms": {duration_ms}'
             )
-            raise e
+            raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.9"
 authors = [
-    {name = "Your Name", email = "your.email@example.com"}
+    {name = "Randall Whitlock"}
 ]
 keywords = ["logging", "log-analysis", "troubleshooting", "devops", "sysadmin"]
 classifiers = [
@@ -58,9 +58,9 @@ dev = [
 log-analyzer = "log_analyzer.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/yourusername/log-analyzer-toolkit"
-Repository = "https://github.com/yourusername/log-analyzer-toolkit"
-Issues = "https://github.com/yourusername/log-analyzer-toolkit/issues"
+Homepage = "https://github.com/randallawhitlock/log-analyzer-toolkit"
+Repository = "https://github.com/randallawhitlock/log-analyzer-toolkit"
+Issues = "https://github.com/randallawhitlock/log-analyzer-toolkit/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- Replace deprecated `declarative_base()` with `DeclarativeBase` class (SQLAlchemy 2.0 style)
- Replace deprecated `datetime.utcnow` with `datetime.now(timezone.utc)` in models and main
- Replace deprecated `@app.on_event("startup")` with `lifespan` async context manager
- Fix dead dict literal in `logging_middleware.py` — assign to `request_context` variable
- Fix bare `raise e` → `raise` in logging middleware exception handler
- Fix version mismatch: root endpoint returned `"0.2.0"` while app declared `"0.2.1"`
- Update `pyproject.toml`: replace placeholder author/URLs with actual values
- Clean up excess blank lines in `crud.py`

## Test plan
- [ ] Verify application starts without deprecation warnings
- [ ] Verify database tables are created on startup via lifespan
- [ ] Verify `/health` returns timezone-aware UTC timestamp
- [ ] Verify `/` returns version `"0.2.1"`
- [ ] Verify structured logging middleware logs request context at debug level