### PR TITLE
feat(frontend): setup Vitest infrastructure

### DIFF
--- a/frontend/src/components/__tests__/HelloWorld.spec.js
+++ b/frontend/src/components/__tests__/HelloWorld.spec.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import HelloWorld from '../HelloWorld.vue'
+
+describe('HelloWorld', () => {
+    it('renders properly', () => {
+        const wrapper = mount(HelloWorld, {
+            props: { msg: 'Hello Vitest' }
+        })
+        expect(wrapper.text()).toContain('Hello Vitest')
+    })
+})

--- a/frontend/src/components/__tests__/StatCard.spec.js
+++ b/frontend/src/components/__tests__/StatCard.spec.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import StatCard from '../StatCard.vue'
+
+describe('StatCard', () => {
+    it('renders title and value', () => {
+        const wrapper = mount(StatCard, {
+            props: { title: 'Total Logs', value: 100 }
+        })
+        expect(wrapper.text()).toContain('Total Logs')
+        expect(wrapper.text()).toContain('100')
+    })
+
+    it('formats percentage', () => {
+        const wrapper = mount(StatCard, {
+            props: { title: 'Success Rate', value: 95.5, format: 'percent' }
+        })
+        expect(wrapper.text()).toContain('95.5%')
+    })
+
+    it('formats bytes', () => {
+        const wrapper = mount(StatCard, {
+            props: { title: 'Size', value: 1024, format: 'bytes' }
+        })
+        expect(wrapper.text()).toContain('1.0 KB')
+    })
+
+    it('applies color class', () => {
+        const wrapper = mount(StatCard, {
+            props: { title: 'Errors', value: 5, color: 'error' }
+        })
+        expect(wrapper.classes()).toContain('color-error')
+    })
+})

--- a/frontend/src/views/__tests__/AnalysesListView.spec.js
+++ b/frontend/src/views/__tests__/AnalysesListView.spec.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import AnalysesListView from '../AnalysesListView.vue'
+
+// Mock the composable
+const mockGetAnalyses = vi.fn()
+vi.mock('../../composables/useApi', async () => {
+    const { ref } = await import('vue')
+    return {
+        useApi: () => ({
+            getAnalyses: mockGetAnalyses,
+            deleteAnalysis: vi.fn(),
+            loading: ref(false),
+            error: ref(null)
+        })
+    }
+})
+
+// Mock router link since it's used
+const RouterLink = {
+    template: '<a><slot></slot></a>',
+    props: ['to']
+}
+
+describe('AnalysesListView', () => {
+    it('renders list of analyses', async () => {
+        mockGetAnalyses.mockResolvedValue({
+            analyses: [
+                { id: '1', filename: 'test.log', detected_format: 'nginx', total_lines: 100, parse_success_rate: 100, error_rate: 0, created_at: '2023-01-01' }
+            ]
+        })
+
+        const wrapper = mount(AnalysesListView, {
+            global: {
+                components: {
+                    RouterLink
+                }
+            }
+        })
+
+        await flushPromises()
+
+        expect(wrapper.text()).toContain('test.log')
+        expect(wrapper.text()).toContain('nginx')
+    })
+
+    it('renders empty state when no analyses', async () => {
+        mockGetAnalyses.mockResolvedValue({
+            analyses: []
+        })
+
+        const wrapper = mount(AnalysesListView, {
+            global: {
+                components: {
+                    RouterLink
+                }
+            }
+        })
+
+        await flushPromises()
+
+        expect(wrapper.text()).toContain('No analyses yet')
+    })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+    plugins: [vue()],
+    test: {
+        environment: 'jsdom',
+        exclude: [...['**/node_modules/**', '**/dist/**']],
+        root: '.',
+        globals: true,
+    },
+})


### PR DESCRIPTION
Sets up Vitest, adds test scripts, and includes initial component tests for StatCard and AnalysesListView.