### PR TITLE
test(backend): increase coverage for deps and main

### DIFF
--- a/backend/tests/test_deps.py
+++ b/backend/tests/test_deps.py
@@ -1,0 +1,102 @@
+"""
+Tests for backend/api/deps.py - dependency injection functions.
+
+Covers:
+- get_analyzer_service returns AnalyzerService instance
+- get_api_key in dev mode (no env var set)
+- get_api_key with valid key
+- get_api_key with invalid key (403)
+- get_api_key with missing header when key is configured (403)
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from backend.api.deps import get_analyzer_service, get_api_key
+from backend.constants import LOG_ANALYZER_API_KEY
+from backend.services.analyzer_service import AnalyzerService
+
+
+class TestGetAnalyzerService:
+    """Tests for the get_analyzer_service dependency."""
+
+    def test_returns_analyzer_service_instance(self):
+        """get_analyzer_service should return an AnalyzerService instance."""
+        service = get_analyzer_service()
+        assert isinstance(service, AnalyzerService)
+
+    def test_returns_new_instance_each_call(self):
+        """Each call should return a fresh instance (not a singleton)."""
+        service1 = get_analyzer_service()
+        service2 = get_analyzer_service()
+        assert service1 is not service2
+
+
+class TestGetApiKeyDevMode:
+    """Tests for get_api_key when no API key is configured (dev mode)."""
+
+    @pytest.mark.asyncio
+    async def test_no_env_key_returns_none(self, monkeypatch):
+        """When LOG_ANALYZER_API_KEY env var is not set, return None (dev mode)."""
+        monkeypatch.delenv(LOG_ANALYZER_API_KEY, raising=False)
+        result = await get_api_key(api_key_header=None)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_env_key_with_header_still_returns_none(self, monkeypatch):
+        """Even with a header provided, if no env key is set, return None."""
+        monkeypatch.delenv(LOG_ANALYZER_API_KEY, raising=False)
+        result = await get_api_key(api_key_header="some-random-key")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_env_key_returns_none(self, monkeypatch):
+        """An empty string env var is treated as unset (dev mode)."""
+        monkeypatch.setenv(LOG_ANALYZER_API_KEY, "")
+        result = await get_api_key(api_key_header=None)
+        assert result is None
+
+
+class TestGetApiKeyAuthenticated:
+    """Tests for get_api_key when an API key is configured."""
+
+    @pytest.mark.asyncio
+    async def test_valid_key_returns_key(self, monkeypatch):
+        """When header matches the configured key, return the key."""
+        monkeypatch.setenv(LOG_ANALYZER_API_KEY, "test-secret-key-123")
+        result = await get_api_key(api_key_header="test-secret-key-123")
+        assert result == "test-secret-key-123"
+
+    @pytest.mark.asyncio
+    async def test_invalid_key_raises_403(self, monkeypatch):
+        """When header does not match the configured key, raise 403."""
+        monkeypatch.setenv(LOG_ANALYZER_API_KEY, "correct-key")
+        with pytest.raises(HTTPException) as exc_info:
+            await get_api_key(api_key_header="wrong-key")
+        assert exc_info.value.status_code == 403
+        assert "credentials" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_header_raises_403(self, monkeypatch):
+        """When key is configured but no header is provided, raise 403."""
+        monkeypatch.setenv(LOG_ANALYZER_API_KEY, "configured-key")
+        with pytest.raises(HTTPException) as exc_info:
+            await get_api_key(api_key_header=None)
+        assert exc_info.value.status_code == 403
+        assert "credentials" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_header_raises_403(self, monkeypatch):
+        """When key is configured but header is empty string, raise 403."""
+        monkeypatch.setenv(LOG_ANALYZER_API_KEY, "configured-key")
+        with pytest.raises(HTTPException) as exc_info:
+            await get_api_key(api_key_header="")
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_exception_detail_message(self, monkeypatch):
+        """Verify the exact error detail message on 403."""
+        monkeypatch.setenv(LOG_ANALYZER_API_KEY, "my-key")
+        with pytest.raises(HTTPException) as exc_info:
+            await get_api_key(api_key_header="bad-key")
+        assert exc_info.value.detail == "Could not validate credentials"

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,5 +1,8 @@
 """
 Tests for main FastAPI application.
+
+Covers: lifespan, health check, root endpoint, CORS, upload size limiting,
+rate limiter wiring, OpenAPI docs, and redoc.
 """
 
 from fastapi.testclient import TestClient
@@ -7,6 +10,9 @@ from fastapi.testclient import TestClient
 from backend.main import app
 
 client = TestClient(app)
+
+
+# ==================== Root & Health Endpoints ====================
 
 
 def test_root_endpoint():
@@ -17,8 +23,9 @@ def test_root_endpoint():
     data = response.json()
     assert "message" in data
     assert "version" in data
-    assert data["version"] == "0.1.0"
+    assert data["version"] == "0.2.1"
     assert "/docs" in data["docs"]
+    assert "/health" in data["health"]
 
 
 def test_health_check():
@@ -28,22 +35,112 @@ def test_health_check():
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "healthy"
-    assert data["version"] == "0.1.0"
+    assert data["version"] == "0.2.1"
     assert "timestamp" in data
 
 
-def test_cors_headers():
-    """Test CORS headers are present."""
+def test_health_check_response_model():
+    """Test health endpoint returns all HealthResponse fields."""
+    response = client.get("/health")
+    data = response.json()
+    assert set(data.keys()) == {"status", "version", "timestamp"}
+
+
+# ==================== CORS ====================
+
+
+def test_cors_headers_allowed_origin():
+    """Test CORS headers are present for allowed origin."""
     response = client.options(
         "/health",
-        headers={"Origin": "http://localhost:5173"}
+        headers={"Origin": "http://localhost:5173"},
     )
-
     assert "access-control-allow-origin" in response.headers
 
 
-def test_openapi_docs():
-    """Test that OpenAPI docs are available."""
-    response = client.get("/docs")
+def test_cors_allows_api_key_header():
+    """Test CORS allows the X-API-Key custom header."""
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Headers": "X-API-Key",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    allow_headers = response.headers.get("access-control-allow-headers", "")
+    assert "x-api-key" in allow_headers.lower()
 
+
+# ==================== OpenAPI / Docs ====================
+
+
+def test_openapi_docs():
+    """Test that Swagger UI docs are available."""
+    response = client.get("/docs")
     assert response.status_code == 200
+
+
+def test_redoc_docs():
+    """Test that ReDoc is available."""
+    response = client.get("/redoc")
+    assert response.status_code == 200
+
+
+def test_openapi_schema():
+    """Test that the OpenAPI JSON schema endpoint works."""
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    schema = response.json()
+    assert "paths" in schema
+    assert schema["info"]["title"] == "Log Analyzer Toolkit API"
+
+
+# ==================== Upload Size Limiting ====================
+
+
+def test_upload_size_limit_rejects_oversized():
+    """POST with content-length exceeding limit returns 413."""
+    huge_size = 200 * 1024 * 1024  # 200 MB
+    response = client.post(
+        "/api/v1/analyze",
+        headers={"content-length": str(huge_size)},
+        content=b"x",
+    )
+    assert response.status_code == 413
+    assert "too large" in response.json()["detail"].lower()
+
+
+def test_upload_size_limit_allows_normal():
+    """POST with reasonable content-length is not blocked by size middleware."""
+    # This will hit the actual route (and may fail for other reasons like missing file),
+    # but should NOT be a 413.
+    response = client.post(
+        "/api/v1/analyze",
+        headers={"content-length": "1024"},
+        content=b"x" * 1024,
+    )
+    assert response.status_code != 413
+
+
+def test_get_requests_bypass_upload_check():
+    """GET requests should never be blocked by the upload size middleware."""
+    response = client.get("/health")
+    assert response.status_code == 200
+
+
+# ==================== Rate Limiter ====================
+
+
+def test_rate_limiter_is_wired():
+    """The app should have a limiter attached to state."""
+    assert hasattr(app.state, "limiter")
+
+
+# ==================== Request ID Header ====================
+
+
+def test_request_id_header_present():
+    """Responses should include X-Request-ID from the logging middleware."""
+    response = client.get("/health")
+    assert "x-request-id" in response.headers


### PR DESCRIPTION
## Summary
- Add 10 new tests for `backend/api/deps.py` (API key validation, service injection)
- Expand `backend/tests/test_main.py` from 4 to 13 tests (CORS, upload limits, rate limiter, middleware)
- All 23 backend tests passing

## Test plan
- [x] `pytest backend/tests/test_deps.py backend/tests/test_main.py -v` — 23 passed
- [x] Pre-commit hooks pass (ruff, formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)