### PR TITLE
chore(logging): standardize backend logging to JSON format

### DIFF
--- a/backend/logging_config.py
+++ b/backend/logging_config.py
@@ -1,0 +1,61 @@
+"""
+Centralized JSON logging configuration for the backend.
+
+Provides a JSONFormatter that outputs valid JSON log lines and a
+setup_logging() helper to wire it into the root logger.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+
+
+class JSONFormatter(logging.Formatter):
+    """Logging formatter that outputs each record as a single JSON object."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_entry: dict = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Merge optional structured extras when provided by callers.
+        for key in (
+            "request_id",
+            "method",
+            "path",
+            "status",
+            "duration_ms",
+            "client_ip",
+            "user_agent",
+            "event",
+            "error",
+        ):
+            value = getattr(record, key, None)
+            if value is not None:
+                log_entry[key] = value
+
+        if record.exc_info and record.exc_info[0] is not None:
+            log_entry["exception"] = self.formatException(record.exc_info)
+
+        return json.dumps(log_entry, default=str)
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure the root logger with the JSON formatter.
+
+    Call once at application startup.  All loggers obtained via
+    ``logging.getLogger(name)`` will inherit this configuration.
+    """
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    # Avoid adding duplicate handlers when called more than once (e.g. tests).
+    if any(isinstance(h.formatter, JSONFormatter) for h in root.handlers):
+        return
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(JSONFormatter())
+    root.addHandler(handler)

--- a/backend/logging_middleware.py
+++ b/backend/logging_middleware.py
@@ -1,84 +1,65 @@
 """
 Structured logging middleware for FastAPI.
-Provides JSON-formatted logs for all requests.
+
+Uses the centralized JSONFormatter from logging_config to produce valid
+JSON log lines for every HTTP request.
 """
 
 import logging
-import sys
 import time
 import uuid
 
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
-# Configure JSON logger
 logger = logging.getLogger("api")
-logger.setLevel(logging.INFO)
-handler = logging.StreamHandler(sys.stdout)
-formatter = logging.Formatter(
-    '{"timestamp": "%(asctime)s", "level": "%(levelname)s", "service": "api", %(message)s}',
-    datefmt="%Y-%m-%dT%H:%M:%S%z",
-)
-handler.setFormatter(formatter)
-logger.addHandler(handler)
 
 
 class StructuredLoggingMiddleware(BaseHTTPMiddleware):
-    """
-    Middleware for structured JSON logging.
-    """
+    """Middleware that logs every request/response as structured JSON."""
 
     async def dispatch(self, request: Request, call_next):
         request_id = str(uuid.uuid4())
         start_time = time.time()
 
-        # Request context for logging
-        request_context = {
-            "req_id": request_id,
-            "method": request.method,
-            "path": request.url.path,
-            "client_ip": request.client.host if request.client else "unknown",
-            "user_agent": request.headers.get("user-agent", "unknown"),
-        }
-
-        logger.debug(f'"event": "request_received", "context": {request_context}')
-
         try:
             response = await call_next(request)
 
-            # Calculate duration
             duration_ms = round((time.time() - start_time) * 1000, 2)
 
-            # Log response
-            log_msg = (
-                f'"event": "request_completed", '
-                f'"req_id": "{request_id}", '
-                f'"method": "{request.method}", '
-                f'"path": "{request.url.path}", '
-                f'"status": {response.status_code}, '
-                f'"duration_ms": {duration_ms}'
-            )
+            extra = {
+                "event": "request_completed",
+                "request_id": request_id,
+                "method": request.method,
+                "path": request.url.path,
+                "status": response.status_code,
+                "duration_ms": duration_ms,
+            }
+
+            msg = f"{request.method} {request.url.path} {response.status_code} {duration_ms}ms"
 
             if response.status_code >= 500:
-                logger.error(log_msg)
+                logger.error(msg, extra=extra)
             elif response.status_code >= 400:
-                logger.warning(log_msg)
+                logger.warning(msg, extra=extra)
             else:
-                logger.info(log_msg)
+                logger.info(msg, extra=extra)
 
-            # Add Request-ID header to response
             response.headers["X-Request-ID"] = request_id
-
             return response
 
         except Exception as e:
             duration_ms = round((time.time() - start_time) * 1000, 2)
             logger.error(
-                f'"event": "request_failed", '
-                f'"req_id": "{request_id}", '
-                f'"method": "{request.method}", '
-                f'"path": "{request.url.path}", '
-                f'"error": "{str(e)}", '
-                f'"duration_ms": {duration_ms}'
+                f"{request.method} {request.url.path} FAILED {duration_ms}ms",
+                extra={
+                    "event": "request_failed",
+                    "request_id": request_id,
+                    "method": request.method,
+                    "path": request.url.path,
+                    "error": str(e),
+                    "duration_ms": duration_ms,
+                },
+                exc_info=True,
             )
             raise

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,9 +27,11 @@ from starlette.types import ASGIApp  # noqa: E402
 from backend.api.schemas import HealthResponse  # noqa: E402
 from backend.constants import MAX_UPLOAD_SIZE_BYTES, MAX_UPLOAD_SIZE_MB  # noqa: E402
 from backend.db.database import init_db  # noqa: E402
+from backend.logging_config import setup_logging  # noqa: E402
 from backend.logging_middleware import StructuredLoggingMiddleware  # noqa: E402
 from backend.rate_limit import limiter  # noqa: E402
 
+setup_logging()
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- Add `backend/logging_config.py` with `JSONFormatter` class producing valid JSON log lines
- Refactor `logging_middleware.py` to use structured `extra` dict instead of manual string interpolation
- Wire `setup_logging()` at app startup so all loggers use JSON format

## Test plan
- [x] `python -c "from backend.logging_config import setup_logging; setup_logging()"` succeeds
- [x] Pre-commit hooks pass (ruff, formatting)
- [x] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)