### PR TITLE
chore(config): unify configuration with pydantic-settings

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,63 @@
+"""
+Unified configuration using pydantic-settings.
+
+All application settings are defined here and can be overridden via
+environment variables or a .env file. Other modules should import
+the ``settings`` singleton rather than reading env vars directly.
+"""
+
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    # Application
+    app_version: str = "0.2.1"
+    debug: bool = False
+
+    # Database
+    database_url: str = "sqlite:///./log_analyzer.db"
+
+    # CORS
+    cors_origins: list[str] = [
+        "http://localhost:5173",
+        "http://localhost:3000",
+        "http://localhost:8080",
+    ]
+
+    # Rate limiting
+    rate_limit_default: str = "60/minute"
+
+    # Upload
+    max_upload_size_mb: int = 100
+
+    # Analysis
+    default_max_errors: int = 100
+    max_errors_limit: int = 1000
+    min_errors_limit: int = 1
+    default_triage_max_errors: int = 50
+
+    # Pagination
+    default_page_size: int = 20
+    max_page_size: int = 100
+    min_page_size: int = 1
+
+    # Upload directory
+    upload_directory: str = "./uploads"
+
+    # Auth - empty string means dev mode (no auth required)
+    api_key: str = ""
+
+    @property
+    def max_upload_size_bytes(self) -> int:
+        return self.max_upload_size_mb * 1024 * 1024
+
+
+settings = Settings()

--- a/backend/constants.py
+++ b/backend/constants.py
@@ -1,29 +1,32 @@
 """
 Shared constants for Backend API.
 
-This module defines configuration constants used throughout the backend
-to avoid magic numbers and ensure consistency.
+Values are sourced from the unified Settings object so they can be
+overridden via environment variables or .env file, while keeping
+backward-compatible module-level names.
 """
 
+from backend.config import settings
+
 # File upload limits
-MAX_UPLOAD_SIZE_BYTES = 100 * 1024 * 1024  # 100MB maximum upload size
-MAX_UPLOAD_SIZE_MB = 100  # For display purposes
+MAX_UPLOAD_SIZE_BYTES = settings.max_upload_size_bytes
+MAX_UPLOAD_SIZE_MB = settings.max_upload_size_mb
 
 # Analysis defaults
-DEFAULT_MAX_ERRORS = 100  # Default maximum errors to collect during analysis
-MAX_ERRORS_LIMIT = 1000  # Hard limit for max_errors parameter
-MIN_ERRORS_LIMIT = 1  # Minimum value for max_errors parameter
+DEFAULT_MAX_ERRORS = settings.default_max_errors
+MAX_ERRORS_LIMIT = settings.max_errors_limit
+MIN_ERRORS_LIMIT = settings.min_errors_limit
 
 # Triage defaults
-DEFAULT_TRIAGE_MAX_ERRORS = 50  # Default maximum errors to analyze during triage
+DEFAULT_TRIAGE_MAX_ERRORS = settings.default_triage_max_errors
 
 # Pagination defaults
-DEFAULT_PAGE_SIZE = 20  # Default number of results per page
-MAX_PAGE_SIZE = 100  # Maximum results per page
-MIN_PAGE_SIZE = 1  # Minimum results per page
+DEFAULT_PAGE_SIZE = settings.default_page_size
+MAX_PAGE_SIZE = settings.max_page_size
+MIN_PAGE_SIZE = settings.min_page_size
 
 # Upload directory
-UPLOAD_DIRECTORY = "./uploads"  # Directory for uploaded log files
+UPLOAD_DIRECTORY = settings.upload_directory
 
 # Authentication
 LOG_ANALYZER_API_KEY = "LOG_ANALYZER_API_KEY"  # Env var name for API key

--- a/backend/db/database.py
+++ b/backend/db/database.py
@@ -4,13 +4,13 @@ Database connection and session management.
 Provides SQLAlchemy engine, session factory, and base model class.
 """
 
-import os
-
 from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
-# Database URL: configurable via env var, defaults to SQLite for dev
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./log_analyzer.db")
+from backend.config import settings
+
+# Database URL from unified settings
+DATABASE_URL = settings.database_url
 
 # SQLite needs check_same_thread=False; PostgreSQL does not
 connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}

--- a/backend/main.py
+++ b/backend/main.py
@@ -25,6 +25,7 @@ from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
 from starlette.types import ASGIApp  # noqa: E402
 
 from backend.api.schemas import HealthResponse  # noqa: E402
+from backend.config import settings  # noqa: E402
 from backend.constants import MAX_UPLOAD_SIZE_BYTES, MAX_UPLOAD_SIZE_MB  # noqa: E402
 from backend.db.database import init_db  # noqa: E402
 from backend.logging_config import setup_logging  # noqa: E402
@@ -48,7 +49,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Log Analyzer Toolkit API",
     description="REST API for analyzing and troubleshooting log files",
-    version="0.2.1",
+    version=settings.app_version,
     docs_url="/docs",
     redoc_url="/redoc",
     lifespan=lifespan,
@@ -61,11 +62,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 # Configure CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:5173",  # Vite dev server
-        "http://localhost:3000",  # Alternative frontend port
-        "http://localhost:8080",  # Another common port
-    ],
+    allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
     allow_headers=["Content-Type", "X-API-Key", "Authorization"],
@@ -103,7 +100,7 @@ async def health_check():
     Returns:
         HealthResponse: Current health status and version
     """
-    return HealthResponse(status="healthy", version="0.2.1", timestamp=datetime.now(timezone.utc))
+    return HealthResponse(status="healthy", version=settings.app_version, timestamp=datetime.now(timezone.utc))
 
 
 # Root endpoint

--- a/backend/rate_limit.py
+++ b/backend/rate_limit.py
@@ -7,4 +7,6 @@ Provides a shared limiter instance used by both main.py and routes.py.
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-limiter = Limiter(key_func=get_remote_address, default_limits=["60/minute"])
+from backend.config import settings
+
+limiter = Limiter(key_func=get_remote_address, default_limits=[settings.rate_limit_default])


### PR DESCRIPTION
## Summary
- Add `backend/config.py` with pydantic-settings `Settings` class as single source of truth
- Update `constants.py`, `database.py`, `rate_limit.py`, and `main.py` to use unified settings
- All values now overridable via env vars or `.env` file
- Backward compatible: `constants.py` still exports same names

## Test plan
- [x] `python -c "from backend.config import settings; print(settings.app_version)"` → `0.2.1`
- [x] All 23 backend tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)