### PR TITLE
docs(api): add interactive API documentation links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,18 @@ make lint       # Check code style
 make clean      # Remove build artifacts
 ```
 
+### Step 4.5: API Documentation
+
+The backend provides interactive API documentation powered by FastAPI:
+
+| Documentation | URL | Description |
+|:---|:---|:---|
+| **Swagger UI** | [http://localhost:8000/docs](http://localhost:8000/docs) | Interactive API explorer with "Try it out" functionality |
+| **ReDoc** | [http://localhost:8000/redoc](http://localhost:8000/redoc) | Clean, readable API reference documentation |
+| **OpenAPI Schema** | [http://localhost:8000/openapi.json](http://localhost:8000/openapi.json) | Raw OpenAPI 3.0 specification (JSON) |
+
+> **Note:** Start the backend server first with `make run` or `./run_dev.sh` before accessing the documentation URLs.
+
 ### Step 5: Python Integration
 
 Integrate the analyzer directly into your monitoring scripts or dashboards.

--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -20,7 +20,7 @@ This document tracks technical debt, known issues, and planned refactoring tasks
 - [ ] **Config**: Unify configuration management (currently split between env vars and constants).
 
 ### Documentation
-- [ ] **API**: Add interactive redoc/swagger documentation links in README.
+- [x] **API**: Add interactive redoc/swagger documentation links in README.
 
 ## 📉 Low Priority / Future
 - [ ] **Performance**: Redis caching for frequent analysis requests.


### PR DESCRIPTION
## Summary
- Add Step 4.5 section to README with Swagger UI, ReDoc, and OpenAPI schema links
- Check off API documentation item in TECHNICAL_DEBT.md

## Test plan
- [x] README renders correctly with new table
- [x] Links point to correct endpoints (/docs, /redoc, /openapi.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)